### PR TITLE
Deprecate COVID-19 Dashboard

### DIFF
--- a/components/callout.js
+++ b/components/callout.js
@@ -16,5 +16,9 @@ export default function Callout({ type, children }) {
 }
 
 Callout.propTypes = {
-  type: PropTypes.oneOf(['success', 'info', 'warning', 'error']).isRequired
+  type: PropTypes.oneOf(['success', 'info', 'warning', 'error'])
+};
+
+Callout.defaultProps = {
+  type: 'info'
 };

--- a/pages/projects/covid-19-dashboard.md
+++ b/pages/projects/covid-19-dashboard.md
@@ -19,6 +19,8 @@ More details, methodology, and definitions can be found at the [New York Times C
 
 Built using [Grafana](https://grafana.com/), [InfluxDB](https://www.influxdata.com/), and [csv-to-influxdb](https://github.com/fabio-miranda/csv-to-influxdb). Data from [New York Times](https://github.com/nytimes/covid-19-data). Running on [AWS](https://aws.amazon.com/), managed by [Terraform](https://www.terraform.io/).
 
-Project site available [here](https://labs.ryanrishi.com/covid-19-dashboard/).
-
 Source available on [Github](https://github.com/ryanrishi/covid-19-grafana).
+
+<Callout>
+  The project site is no longer live, but there are instructions on how to run the project in the source code link above.
+</Callout>


### PR DESCRIPTION
Counterpart to https://github.com/ryanrishi/covid-19-grafana/pull/1