### PR TITLE
Disable Loudness Wars chart resize

### DIFF
--- a/components/projects/loudness-wars/index.js
+++ b/components/projects/loudness-wars/index.js
@@ -3,11 +3,21 @@ import { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { event } from '../../../lib/ga';
 
-const margin = {
-  top: 10,
-  right: 30,
-  bottom: 30,
-  left: 60
+const getMargin = ({ width }) => {
+  const margin = {
+    top: 10,
+    right: 30,
+    bottom: 30,
+    left: 60
+  };
+
+  if (width < 768) {
+    // tablet or smaller
+    margin.left = 30;
+    margin.right = 10;
+  }
+
+  return margin;
 };
 
 const trackFillColor = '#69b3a2';
@@ -58,6 +68,7 @@ const drawChart = async (svgRef, setSelectedTrack) => {
   });
 
   const { width, height } = svgRef.current.viewBox.baseVal;
+  const margin = getMargin({ width });
   const h = height - margin.top - margin.bottom;
   const w = width - margin.left - margin.right;
 
@@ -103,7 +114,7 @@ const drawChart = async (svgRef, setSelectedTrack) => {
     .text('Loudness (dB)');
 
   const transitionDuration = 200;
-  const r = 5;
+  const r = Math.min((width / 480) * 5, 5);
 
   // tooltip
   const tooltip = d3.select('body')

--- a/components/projects/loudness-wars/index.js
+++ b/components/projects/loudness-wars/index.js
@@ -1,6 +1,5 @@
 /* eslint indent: ["warn", 2] */
 import { useEffect, useRef, useState } from 'react';
-import debounce from 'lodash.debounce';
 import * as d3 from 'd3';
 import { event } from '../../../lib/ga';
 
@@ -257,21 +256,12 @@ const Chart = () => {
   };
 
   useEffect(() => {
-    const handleResize = debounce(() => {
-      setDimensions({
-        height: window.innerHeight,
-        width: window.innerWidth
-      });
+    setDimensions({
+      height: window.innerHeight,
+      width: window.innerWidth
+    });
 
-      drawChart(svg, setSelectedTrack);
-    }, 250);
-
-    // trigger a resize once component is mounted since window is undefined with Next.js SSR
-    handleResize();
-
-    window.addEventListener('resize', handleResize);
-
-    return () => window.removeEventListener('resize', handleResize);
+    drawChart(svg, setSelectedTrack);
   }, [svg]);
 
   return (

--- a/components/projects/loudness-wars/index.js
+++ b/components/projects/loudness-wars/index.js
@@ -43,7 +43,8 @@ const drawChart = async (svgRef, setSelectedTrack) => {
     })(),
     releaseDatePrecision: track.release_date_precision,
     loudness: track.loudness
-  })).sort((a, b) => a.releaseDate - b.releaseDate));
+  })).filter(x => x.releaseDate.getFullYear() >= 1970) // only 2 tracks in 1969, insufficient data size
+    .sort((a, b) => a.releaseDate - b.releaseDate));
 
   const minDate = data[0].releaseDate;
   const maxDate = data[data.length - 1].releaseDate;

--- a/cypress/integration/projects/loudness-wars.spec.js
+++ b/cypress/integration/projects/loudness-wars.spec.js
@@ -28,7 +28,7 @@ describe('Projects | Loudness Wars', () => {
       const radius = 1.5;
 
       beforeEach(() => {
-        $circle = cy.get('svg circle').first();
+        $circle = cy.get('svg circle').eq(1); // .first() is covered by another circle
         $circle.trigger('mouseover');
       });
 
@@ -51,7 +51,7 @@ describe('Projects | Loudness Wars', () => {
       let $circle;
 
       beforeEach(() => {
-        $circle = cy.get('svg circle').first();
+        $circle = cy.get('svg circle').eq(1); // .first() is covered by another circle
         $circle.click();
       });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dayjs": "^1.10.4",
     "gray-matter": "^4.0.2",
     "hamburger-react": "^2.4.0",
-    "lodash.debounce": "^4.0.8",
     "next": "~10.0.5",
     "next-compose-plugins": "^2.2.1",
     "next-mdx-enhanced": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,11 +4320,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"


### PR DESCRIPTION
Mobile Chrome/Safari shows and hides search bar and bottom menu as you scroll, changing the viewport, which triggers a resize.

This is a quick fix to not redraw the chart anytime the viewport changes. Hoping to re-enable redrawing when the viewport changes at some point in the future.

https://user-images.githubusercontent.com/5033038/126018562-4a041c59-ccf1-4452-9052-5c161ad55b81.mov

