### PR TITLE
Update Github Actions to run checks on ubuntu-latest

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,7 +2,7 @@ name: Cypress
 on: [push]
 jobs:
   cypress-run:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,7 +2,7 @@ name: ESLint
 on: [push]
 jobs:
   eslint:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   percy:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Github removed the `ubuntu-16.04` test runner on September 20, 2021 ([source](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)).

This PR updates Github action runners to use `ubuntu-latest`. See [`runs-on`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on) for more information.