### PR TITLE
Add Vercel Speed Insights for Core Web Vitals tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import 'tailwindcss/tailwind.css'
 import './globals.css'
 
 import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 import Script from 'next/script'
 import type { Metadata } from 'next/types'
 
@@ -72,6 +73,7 @@ export default function RootLayout({ children }) {
         </div>
         </Providers>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   )

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tailwindcss/typography": "^0.5.10",
     "@types/mdx": "^2.0.13",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "classnames": "^2.3.1",
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,6 +1258,11 @@
   resolved "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz"
   integrity sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==
 
+"@vercel/speed-insights@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.2.0.tgz#1656c3596d4ec02d93d301ca45944c1b9b245186"
+  integrity sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==
+
 acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"


### PR DESCRIPTION
Enables monitoring of page load performance, Core Web Vitals (LCP, FID, CLS), and real user monitoring data in Vercel dashboard.

🤖 Generated with [Claude Code](https://claude.ai/code)