### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,5 +1,7 @@
 name: ESLint
 on: [push]
+permissions:
+  contents: read
 jobs:
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ryanrishi/ryanrishi.com/security/code-scanning/7](https://github.com/ryanrishi/ryanrishi.com/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/eslint.yml` at the workflow root so it applies to all jobs (including `eslint`). For this workflow, `contents: read` is the minimal required permission for `actions/checkout` and read-only repository access during linting. This preserves behavior while enforcing least privilege and satisfying CodeQL.

Concretely:
- Edit `.github/workflows/eslint.yml`.
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it near the top level (after `on:` is a clear location), before `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
