### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,7 @@
 name: Cypress + Percy
 on: [push]
+permissions:
+  contents: read
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ryanrishi/ryanrishi.com/security/code-scanning/5](https://github.com/ryanrishi/ryanrishi.com/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/cypress.yml` at the workflow root so it applies to all jobs unless overridden.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This supports `actions/checkout` and does not grant unnecessary write scopes. No imports, methods, or dependency changes are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
