### PR TITLE
Fix flaky Percy mobile-nav snapshots

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,10 +1,22 @@
 'use client'
 
+import { MotionGlobalConfig } from 'framer-motion'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { ThemeProvider } from 'next-themes'
 import { Suspense, useEffect } from 'react'
 
 import { pageview } from '@/lib/ga'
+
+declare global {
+  interface Window {
+    Cypress?: unknown
+  }
+}
+
+// Skip Framer Motion animations under Cypress so Percy snapshots are deterministic
+if (typeof window !== 'undefined' && window.Cypress) {
+  MotionGlobalConfig.skipAnimations = true
+}
 
 function PageView() {
   const pathname = usePathname()

--- a/cypress/e2e/mobile-nav.cy.js
+++ b/cypress/e2e/mobile-nav.cy.js
@@ -14,7 +14,7 @@ describe('Mobile Navigation', () => {
   it('displays hamburger menu on mobile', () => {
     cy.get('[data-testid="hamburger-menu"]').should('be.visible')
     cy.get('nav').should('not.be.visible') // Desktop nav should be hidden
-    cy.get('[aria-label="Dark mode toggle"]').should('be.visible')
+    cy.get('[aria-label="Dark mode toggle"]:visible').should('be.visible')
     cy.percyMobileSnapshot('Mobile Nav - Closed')
   })
 
@@ -40,7 +40,7 @@ describe('Mobile Navigation', () => {
     // Wait until animated items have fully settled
     cy.waitForMobileNavSettled()
 
-    cy.get('[aria-label="Dark mode toggle"]').should('be.visible')
+    cy.get('[aria-label="Dark mode toggle"]:visible').should('be.visible')
 
     // Take Percy screenshot of open mobile nav
     cy.percyMobileSnapshot('Mobile Nav - Open')
@@ -96,7 +96,7 @@ describe('Mobile Navigation', () => {
     // Wait until animated items have fully settled
     cy.waitForMobileNavSettled()
 
-    cy.get('[aria-label="Dark mode toggle"]').should('be.visible')
+    cy.get('[aria-label="Dark mode toggle"]:visible').should('be.visible')
 
     // Take Percy screenshot of active state at mobile width only
     cy.percyMobileSnapshot('Mobile Nav - Active State (Blog)')

--- a/cypress/e2e/mobile-nav.cy.js
+++ b/cypress/e2e/mobile-nav.cy.js
@@ -14,6 +14,7 @@ describe('Mobile Navigation', () => {
   it('displays hamburger menu on mobile', () => {
     cy.get('[data-testid="hamburger-menu"]').should('be.visible')
     cy.get('nav').should('not.be.visible') // Desktop nav should be hidden
+    cy.get('[aria-label="Dark mode toggle"]').should('be.visible')
     cy.percyMobileSnapshot('Mobile Nav - Closed')
   })
 
@@ -38,6 +39,8 @@ describe('Mobile Navigation', () => {
 
     // Wait until animated items have fully settled
     cy.waitForMobileNavSettled()
+
+    cy.get('[aria-label="Dark mode toggle"]').should('be.visible')
 
     // Take Percy screenshot of open mobile nav
     cy.percyMobileSnapshot('Mobile Nav - Open')
@@ -92,6 +95,8 @@ describe('Mobile Navigation', () => {
 
     // Wait until animated items have fully settled
     cy.waitForMobileNavSettled()
+
+    cy.get('[aria-label="Dark mode toggle"]').should('be.visible')
 
     // Take Percy screenshot of active state at mobile width only
     cy.percyMobileSnapshot('Mobile Nav - Active State (Blog)')


### PR DESCRIPTION
## Problem
Mobile-nav Percy snapshots flaked with a **missing logo** and/or **missing dark-mode toggle**, forcing manual approvals and burning Percy quota. There was no `CYPRESS` animation kill-switch (despite the assumption there was), so Framer Motion animations raced the snapshots:

- Logo draws via a ~1.6s `pathLength` spring with `fill="none"` — invisible until done
- Dark-mode toggle returns `null` until it hydrates; the "Closed" snapshot had no wait

## Fix
- `app/providers.tsx`: set `MotionGlobalConfig.skipAnimations = true` when `window.Cypress` is present, so animations settle instantly. Gated on Cypress — no effect on real visitors, no build changes.
- `cypress/e2e/mobile-nav.cy.js`: assert the (visible mobile) dark-mode toggle is present before each snapshot.

## Verified
All 7 mobile-nav specs pass. A no-wait capture at mobile viewport shows the logo fully drawn and toggle present, confirming `skipAnimations` engages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)