### PR TITLE
Disable d3 animations for Loudness Wars Percy snapshots

### DIFF
--- a/app/components/projects/loudness-wars/index.tsx
+++ b/app/components/projects/loudness-wars/index.tsx
@@ -167,10 +167,15 @@ const drawChart = async (svgRef: RefObject<SVGSVGElement | null>, setSelectedTra
   }
 
   function onMouseIn(e: MouseEvent, d) {
-    d3.select(this)
-      .transition()
-      .duration(transitionDuration)
-      .attr('r', 2 * r)
+    const circle = d3.select(this)
+    if (skipAnimations) {
+      circle.attr('r', 2 * r)
+    } else {
+      circle
+        .transition()
+        .duration(transitionDuration)
+        .attr('r', 2 * r)
+    }
 
     tooltip
       .interrupt()
@@ -198,7 +203,14 @@ const drawChart = async (svgRef: RefObject<SVGSVGElement | null>, setSelectedTra
   }
 
   function onMouseOut() {
-    d3.select(this)
+    const circle = d3.select(this)
+    if (skipAnimations) {
+      circle.attr('r', r)
+      tooltip.style('opacity', 0).style('display', 'none')
+      return
+    }
+
+    circle
       .transition()
       .duration(transitionDuration)
       .attr('r', r)

--- a/cypress/e2e/projects/loudness-wars.cy.js
+++ b/cypress/e2e/projects/loudness-wars.cy.js
@@ -1,9 +1,13 @@
 // keep this in sync with projects/loudness-wars/index.tsx L35
 const selectedTrackFillColor = '#f38f9f'
 
+const skipChartAnimations = (win) => {
+  win.__SKIP_CHART_ANIMATIONS__ = true
+}
+
 describe('Projects | Loudness Wars', () => {
   beforeEach(() => {
-    cy.visit('/projects/loudness-wars')
+    cy.visit('/projects/loudness-wars', { onBeforeLoad: skipChartAnimations })
     cy.viewport('macbook-13')
     cy.waitForLogoAnimations()
   })


### PR DESCRIPTION
## Problem

The `__SKIP_CHART_ANIMATIONS__` flag was wired into `projects.cy.js` (the listing page) but **not** `loudness-wars.cy.js`, so the actual chart page's Percy snapshots still ran with d3 animations live. Two flaky snapshots resulted:

- **"Loudness Wars"** — captured a blank/partial chart because the staggered 1000ms circle entrance transition hadn't finished when Percy snapshotted.
- **"Spotify embed"** — Cypress `.click()` fires a `mouseover`, which starts the 200ms hover-enlarge (`r → 2r`) transition; Percy caught it mid-flight, so the focused bubble size varied run-to-run.

## Fix

- Wire `onBeforeLoad: skipChartAnimations` into the loudness-wars test's `cy.visit`, matching the pattern already used in `projects.cy.js`.
- Extend `skipAnimations` in the component to also short-circuit the hover resize transitions (`onMouseIn` / `onMouseOut`), so the resize is instant and deterministic.

Percy compares each snapshot against its own baseline, so the focused bubble being larger than the un-focused main chart is expected — what matters is that it's now stable run-to-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)