### PR TITLE
Add Open Graph images and fix metadata gaps

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import path from 'path'
 
 import TagPill from '@/components/tag-pill'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 
 dayjs.extend(utc)
@@ -26,23 +27,27 @@ export async function generateMetadata ({ params }: { params: Promise<{ slug: st
   const fileContent = fs.readFileSync(filePath, 'utf8')
   const { data: frontmatter } = matter(fileContent)
 
+  const images = [frontmatter.image ?? ogImage(frontmatter.title)]
+
   return {
     title: frontmatter.title,
     description: frontmatter.description,
     openGraph: {
-      title: frontmatter.title,
+      ...baseOpenGraph,
       type: 'article',
+      title: frontmatter.title,
+      description: frontmatter.description,
+      url: `${SITE_URL}/blog/${decodedSlug}`,
       publishedTime: frontmatter.publishedAt,
-      authors: 'Ryan Rishi',
-      url: `https://ryanrishi.com/blog/${decodedSlug}`,
-      images: [
-        { url: `https://ryanrishi.com/${frontmatter.image}` },
-      ],
-    tags: frontmatter.tags,
+      authors: SITE_NAME,
+      tags: frontmatter.tags,
+      images,
     },
     twitter: {
+      ...baseTwitter,
       title: frontmatter.title,
-      images: `https://ryanrishi.com/${frontmatter.image}`,
+      description: frontmatter.description,
+      images,
     },
   }
 }

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -4,17 +4,29 @@ import { Metadata } from 'next'
 
 import ContentRow from '@/components/content-row'
 import { FancyH1 } from '@/components/headings'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 
 dayjs.extend(utc)
 
+const title = 'Blog'
+const description = 'Writing about technology, music, and life.'
+
 export const metadata: Metadata = {
-  title: 'Blog',
+  title,
+  description,
   openGraph: {
-    title: 'Blog',
+    ...baseOpenGraph,
+    title,
+    description,
+    url: `${SITE_URL}/blog`,
+    images: [ogImage(title, description)],
   },
   twitter: {
-    title: 'Blog',
+    ...baseTwitter,
+    title,
+    description,
+    images: [ogImage(title, description)],
   },
 }
 

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -2,14 +2,26 @@ import classNames from 'classnames'
 import { Metadata } from 'next/types'
 
 import { FancyH1 } from '@/components/headings'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
+
+const title = 'Contact'
+const description = 'Have a question, an idea, or just want to talk shop or music? Drop me a note.'
 
 export const metadata: Metadata = {
-  title: 'Contact',
+  title,
+  description,
   openGraph: {
-    title: 'Contact',
+    ...baseOpenGraph,
+    title,
+    description,
+    url: `${SITE_URL}/contact`,
+    images: [ogImage(title, description)],
   },
   twitter: {
-    title: 'Contact',
+    ...baseTwitter,
+    title,
+    description,
+    images: [ogImage(title, description)],
   },
 }
 

--- a/app/(site)/music/page.tsx
+++ b/app/(site)/music/page.tsx
@@ -1,18 +1,26 @@
 import { Metadata } from 'next'
 
 import { FancyH1 } from '@/components/headings'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
+
+const title = 'Music'
+const description = 'My music projects and performances'
 
 export const metadata: Metadata = {
-  title: 'Music',
-  description: 'My music projects and performances',
+  title,
+  description,
   openGraph: {
-    title: 'Music',
-    description: 'My music projects and performances',
+    ...baseOpenGraph,
+    title,
+    description,
+    url: `${SITE_URL}/music`,
+    images: [ogImage(title, description)],
   },
   twitter: {
-    card: 'summary',
-    title: 'Music',
-    description: 'My music projects and performances',
+    ...baseTwitter,
+    title,
+    description,
+    images: [ogImage(title, description)],
   },
 }
 

--- a/app/(site)/projects/[slug]/page.tsx
+++ b/app/(site)/projects/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Metadata } from 'next'
 import path from 'path'
 
 import TagPill from '@/components/tag-pill'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllProjects } from '@/lib/projects'
 
 
@@ -23,23 +24,25 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const fileContent = fs.readFileSync(filePath, 'utf8')
   const { data: frontmatter } = matter(fileContent)
 
+  const images = [frontmatter.image?.src ?? ogImage(frontmatter.name)]
+
   return {
     title: frontmatter.name,
     description: frontmatter.description,
     openGraph: {
-      title: frontmatter.name,
+      ...baseOpenGraph,
       type: 'article',
+      title: frontmatter.name,
+      description: frontmatter.description,
+      url: `${SITE_URL}/projects/${decodedSlug}`,
       publishedTime: frontmatter.date,
-      url: `https://ryanrishi.com/projects/${decodedSlug}`,
-      ...(frontmatter.image && {
-        images: [{ url: `https://ryanrishi.com${frontmatter.image.src}` }],
-      }),
+      images,
     },
     twitter: {
+      ...baseTwitter,
       title: frontmatter.name,
-      ...(frontmatter.image && {
-        images: `https://ryanrishi.com${frontmatter.image.src}`,
-      }),
+      description: frontmatter.description,
+      images,
     },
   }
 }

--- a/app/(site)/projects/page.tsx
+++ b/app/(site)/projects/page.tsx
@@ -2,17 +2,29 @@ import { compareDesc } from 'date-fns'
 import { Metadata } from 'next'
 
 import { FancyH1 } from '@/components/headings'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllProjects } from '@/lib/projects'
 
 import ProjectItem from './project-item'
 
+const title = 'Projects'
+const description = 'Data visualization, conference talks, and web scrapers.'
+
 export const metadata: Metadata = {
-  title: 'Projects',
+  title,
+  description,
   openGraph: {
-    title: 'Projects',
+    ...baseOpenGraph,
+    title,
+    description,
+    url: `${SITE_URL}/projects`,
+    images: [ogImage(title, description)],
   },
   twitter: {
-    title: 'Projects',
+    ...baseTwitter,
+    title,
+    description,
+    images: [ogImage(title, description)],
   },
 }
 

--- a/app/(site)/tags/[tag]/page.tsx
+++ b/app/(site)/tags/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import Link from '@/components/link'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 import { getAllProjects } from '@/lib/projects'
 
@@ -23,16 +24,23 @@ export async function generateStaticParams() {
 
 export const generateMetadata = async ({ params }: { params: Promise<{ tag: string }> }): Promise<Metadata> => {
   const { tag } = await params
+  const description = `Content tagged with "${tag}"`
 
   return {
     title: tag,
-    description: `Content tagged with "${tag}"`,
+    description,
     openGraph: {
+      ...baseOpenGraph,
       title: tag,
-      url: `https://ryanrishi.com/tags/${kebabCase(tag)}`,
+      description,
+      url: `${SITE_URL}/tags/${kebabCase(tag)}`,
+      images: [ogImage(tag, description)],
     },
     twitter: {
+      ...baseTwitter,
       title: tag,
+      description,
+      images: [ogImage(tag, description)],
     },
   }
 }

--- a/app/(site)/tags/page.tsx
+++ b/app/(site)/tags/page.tsx
@@ -3,16 +3,28 @@ import type { Metadata } from 'next'
 
 import { FancyH1 } from '@/components/headings'
 import TagPill from '@/components/tag-pill'
+import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 import { getAllProjects } from '@/lib/projects'
 
+const title = 'Tags'
+const description = 'Browse posts and projects by topic.'
+
 export const metadata: Metadata = {
-  title: 'Tags',
+  title,
+  description,
   openGraph: {
-    title: 'Tags',
+    ...baseOpenGraph,
+    title,
+    description,
+    url: `${SITE_URL}/tags`,
+    images: [ogImage(title, description)],
   },
   twitter: {
-    title: 'Tags',
+    ...baseTwitter,
+    title,
+    description,
+    images: [ogImage(title, description)],
   },
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,36 +7,34 @@ import { GeistSans } from 'geist/font/sans'
 import Script from 'next/script'
 import type { Metadata } from 'next/types'
 
+import { baseOpenGraph, baseTwitter, SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/metadata'
+
 import Providers from './providers'
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://ryanrishi.com'),
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: 'Ryan Rishi',
-    template: '%s | Ryan Rishi',
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
   },
+  description: SITE_DESCRIPTION,
   authors: {
-    name: 'Ryan Rishi',
-    url: new URL('https://ryanrishi.com'),
+    name: SITE_NAME,
+    url: new URL(SITE_URL),
   },
   openGraph: {
-    type: 'website',
+    ...baseOpenGraph,
     title: {
-      default: 'Ryan Rishi',
-      template: '%s | Ryan Rishi',
+      default: SITE_NAME,
+      template: `%s | ${SITE_NAME}`,
     },
-    description: 'Full-stack software engineer and musician who loves cooking, camping, and flying.',
-    url: 'https://ryanrishi.com',
-    siteName: 'Ryan Rishi',
-    locale: 'en_US',
   },
   twitter: {
+    ...baseTwitter,
     title: {
-      default: 'Ryan Rishi',
-      template: '%s | Ryan Rishi',
+      default: SITE_NAME,
+      template: `%s | ${SITE_NAME}`,
     },
-    creator: '@ryanrishi',
-    card: 'summary_large_image',
   },
   verification: {
     google: 'kausNF9hQubv5pYpPGZt6JjoZ45qF__IlkNNrlr',

--- a/app/lib/metadata.ts
+++ b/app/lib/metadata.ts
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+
+export const SITE_URL = 'https://ryanrishi.com'
+export const SITE_NAME = 'Ryan Rishi'
+export const SITE_DESCRIPTION = 'Full-stack software engineer and musician who loves cooking, camping, and flying.'
+
+export function ogImage(title?: string, subtitle?: string): string {
+  const params = new URLSearchParams()
+  if (title) params.set('title', title)
+  if (subtitle) params.set('subtitle', subtitle)
+
+  const query = params.toString()
+  return query ? `/og?${query}` : '/og'
+}
+
+export const baseOpenGraph: Metadata['openGraph'] = {
+  type: 'website',
+  siteName: SITE_NAME,
+  locale: 'en_US',
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  images: [ogImage()],
+}
+
+export const baseTwitter: Metadata['twitter'] = {
+  card: 'summary_large_image',
+  creator: '@ryanrishi',
+  images: [ogImage()],
+}

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -1,0 +1,69 @@
+import { ImageResponse } from 'next/og'
+
+import { SITE_DESCRIPTION, SITE_NAME } from '@/lib/metadata'
+
+export function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const title = searchParams.get('title') ?? SITE_NAME
+  const subtitle = searchParams.get('subtitle') ?? SITE_DESCRIPTION
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: '#0f172a',
+          padding: '90px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              backgroundColor: '#D33A2C',
+              marginRight: 24,
+            }}
+          />
+          <div
+            style={{
+              fontSize: 30,
+              letterSpacing: 6,
+              textTransform: 'uppercase',
+              color: '#D33A2C',
+            }}
+          >
+            ryanrishi.com
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              fontSize: 88,
+              fontWeight: 800,
+              lineHeight: 1.05,
+              color: '#f8fafc',
+            }}
+          >
+            {title}
+          </div>
+          {subtitle && (
+            <div style={{ display: 'flex', fontSize: 34, color: '#94a3b8', marginTop: 28 }}>
+              {subtitle}
+            </div>
+          )}
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    },
+  )
+}

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -2,10 +2,12 @@ import { ImageResponse } from 'next/og'
 
 import { SITE_DESCRIPTION, SITE_NAME } from '@/lib/metadata'
 
+const clamp = (value: string, max: number) => value.length > max ? `${value.slice(0, max - 1)}…` : value
+
 export function GET(request: Request) {
   const { searchParams } = new URL(request.url)
-  const title = searchParams.get('title') ?? SITE_NAME
-  const subtitle = searchParams.get('subtitle') ?? SITE_DESCRIPTION
+  const title = clamp(searchParams.get('title') ?? SITE_NAME, 100)
+  const subtitle = clamp(searchParams.get('subtitle') ?? SITE_DESCRIPTION, 200)
 
   return new ImageResponse(
     (

--- a/cypress/e2e/blog.cy.js
+++ b/cypress/e2e/blog.cy.js
@@ -17,6 +17,11 @@ describe('Blog', () => {
       cy.get('head meta[property="og:title"]').should('have.attr', 'content', title)
     })
 
+    it('og:image', () => {
+      cy.get('head meta[property="og:image"]').should('have.attr', 'content').and('include', '/og?title=Blog')
+      cy.get('head meta[name="twitter:image"]').should('have.attr', 'content').and('include', '/og?title=Blog')
+    })
+
     it('og:article', () => {
       cy.get('[data-test-blog-post] h2 a').first().click()
       cy.url().should('match', /\/blog\/[0-9a-z-]*$/)
@@ -24,6 +29,9 @@ describe('Blog', () => {
       cy.get('head meta[property="article:author"]').should('have.attr', 'content', 'Ryan Rishi')
       cy.get('head meta[property="article:published_time"]').should('have.attr', 'content')
         .and('match', /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+      // regression guard: post image resolves with a single slash (no `//img`)
+      cy.get('head meta[property="og:image"]').should('have.attr', 'content')
+        .and('match', /^https:\/\/ryanrishi\.com\/img\/.+/)
     })
   })
 

--- a/cypress/e2e/contact.cy.js
+++ b/cypress/e2e/contact.cy.js
@@ -7,6 +7,8 @@ describe('Contact', () => {
   it('meta', () => {
     const title = 'Contact | Ryan Rishi'
     cy.title().should('eq', title)
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', title)
+    cy.get('head meta[property="og:image"]').should('have.attr', 'content').and('include', '/og?title=Contact')
   })
 
   it('renders contact page', () => {

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -14,6 +14,11 @@ describe('Home', () => {
     it('author', () => {
       cy.get('head meta[name="author"]').should('have.attr', 'content', 'Ryan Rishi')
     })
+
+    it('og:image', () => {
+      cy.get('head meta[property="og:image"]').should('have.attr', 'content', 'https://ryanrishi.com/og')
+      cy.get('head meta[name="twitter:image"]').should('have.attr', 'content', 'https://ryanrishi.com/og')
+    })
   })
 
   it('renders the home page', () => {

--- a/cypress/e2e/projects.cy.js
+++ b/cypress/e2e/projects.cy.js
@@ -15,6 +15,19 @@ describe('Projects', () => {
       cy.title().should('eq', title)
       cy.get('head meta[property="og:title"]').should('have.attr', 'content', title)
     })
+
+    it('og:image', () => {
+      cy.get('head meta[property="og:image"]').should('have.attr', 'content').and('include', '/og?title=Projects')
+      cy.get('head meta[name="twitter:image"]').should('have.attr', 'content').and('include', '/og?title=Projects')
+    })
+
+    it('og:article', () => {
+      cy.get('li a').first().click()
+      cy.url().should('include', '/projects/')
+      cy.get('head meta[property="og:type"]').should('have.attr', 'content', 'article')
+      cy.get('head meta[property="og:image"]').should('have.attr', 'content')
+        .and('match', /^https:\/\/ryanrishi\.com\/img\/.+/)
+    })
   })
 
   it('renders the project page', () => {


### PR DESCRIPTION
## What

Adds real Open Graph / Twitter card content across the site and fixes several latent metadata bugs.

Previously the OG wiring existed but was quietly broken:
- **No `og:image`** on `/`, `/blog`, or `/projects` — they shared as blank `summary_large_image` cards.
- The index pages set `openGraph: { title: 'Blog' }`, which (per Next's shallow object-level merge) **replaced the entire root `openGraph`**, dropping `description`, `url`, `siteName`, `type`, and `locale`.
- Blog post images built `https://ryanrishi.com/${frontmatter.image}` where `frontmatter.image` already starts with `/` → **double slash** (`//img/...`).

## How

- **`app/og/route.tsx`** — dynamic OG image generator (`next/og`), a branded 1200×630 card (slate-900, valencia accent, wordmark + title + subtitle). Takes `?title=` / `?subtitle=`.
- **`app/lib/metadata.ts`** — single source of truth (`SITE_*`, `baseOpenGraph`, `baseTwitter`, `ogImage()`); every page spreads the shared base and overrides only what differs.
- **Root layout / `/blog` / `/projects`** — emit full OG + Twitter with a generated image.
- **`/blog/:slug` / `/projects/:slug`** — double-slash fixed (relative paths resolved via `metadataBase`), added `og:description` + `siteName`, and a generated fallback (`frontmatter.image ?? ogImage(title)`) for any post/project without its own image. Frontmatter images still win where present.

I used an image **route referenced from metadata** rather than the `opengraph-image.tsx` file convention on purpose: file-based images have *higher priority and override `generateMetadata`*, which would clobber the per-post frontmatter images.

## Testing

- Verified every page's resolved meta tags against the running server (absolute URLs, single-slash image paths, restored index fields).
- Cypress: added `og:image` coverage on home/blog/projects plus a **regression guard** for the double-slash fix. All 16 tests across the three specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)