### PR TITLE
Fix flaky Loudness Wars Percy snapshot in projects spec

### DIFF
--- a/cypress/e2e/projects.cy.js
+++ b/cypress/e2e/projects.cy.js
@@ -49,6 +49,11 @@ describe('Projects', () => {
         cy.get('li a').eq(i).click()
         cy.url().should('include', '/projects/')
         cy.waitForLogoAnimations()
+        cy.url().then((url) => {
+          if (url.includes('loudness-wars')) {
+            cy.get('svg [data-test-trendline="true"]') // wait for chart to finish rendering
+          }
+        })
         cy.get('h1').scrollIntoView()
         cy.get('h1').first().then(($title) => {
           const title = $title.text()


### PR DESCRIPTION
## Problem

The **"Loudness Wars"** Percy snapshot (seen flaking on #518, build #1270) sometimes captured the project page with no chart at all.

That snapshot comes from the `each project` loop in `projects.cy.js`, which clicks into every project page and snapshots it by `h1` title. The test waits for images via `waitForImagesLoaded` — but the Loudness Wars chart isn't an image. It's drawn by d3 after an async CSV fetch (`d3.csv('/loudness-wars.csv')`), so when the snapshot won the race, Percy captured an empty `<svg>`.

#525 fixed the `Projects | Loudness Wars…` snapshots in the dedicated `loudness-wars.cy.js` spec (which already waits for the trendline), but this listing-driven snapshot was never covered.

## Fix

When the visited project is the Loudness Wars page, wait for `[data-test-trendline]` before snapshotting — the trendline is the last element `drawChart` renders, so its presence guarantees the circles are placed. Same pattern `loudness-wars.cy.js` already uses.

If CI is ever too slow to render the chart, the test now fails loudly instead of silently snapshotting a blank chart.

## Testing

- Prod build + `npx cypress run --spec cypress/e2e/projects.cy.js` locally (Percy-free): 4 consecutive clean runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)