### PR TITLE
Gate /_test page to non-production deployments

### DIFF
--- a/app/(site)/%5Ftest/page.tsx
+++ b/app/(site)/%5Ftest/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 
 import { FancyH1 } from '@/components/headings'
 
@@ -6,6 +7,10 @@ export const metadata: Metadata = {
   title: 'test',
   description: 'this is only a test',
   keywords: ['test', 'second tag'],
+  robots: {
+    index: false,
+    follow: false,
+  },
   openGraph: {
     type: 'article',
     title: 'test',
@@ -22,6 +27,10 @@ export const metadata: Metadata = {
 }
 
 export default async function Test() {
+  if (process.env.VERCEL_ENV === 'production') {
+    notFound()
+  }
+
   const { default: Test } = await import('./test.mdx')
 
   return (


### PR DESCRIPTION
## Problem

`app/(site)/%5Ftest/page.tsx` is the kitchen-sink MDX test page (headings, callouts, code blocks) that Cypress and Percy use to verify MDX rendering and metadata. It was shipping to production and was live and indexable at https://ryanrishi.com/_test.

Worse, it advertised fake OG metadata to anyone (or any crawler) who found it — `title: "test"`, `description: "this is only a test"`, and an `og:image` pointing at `/img/nope.png`, which does not exist in `public/`. So the one page on the site with deliberately bogus social metadata was also the one pointing at a broken image.

## Fix

Keep the page and its Cypress coverage; just don't serve it on the real site.

- Return `notFound()` when `process.env.VERCEL_ENV === 'production'`. Vercel sets this at build time; it is `'preview'` on preview deploys and undefined locally and in CI, so the page stays available everywhere except production.
- Add `robots: { index: false, follow: false }` to the exported metadata as belt-and-braces — this also covers preview deployments, which remain reachable by design.

The gate is **build-time**, not request-time: `/_test` is a plain static route, so `VERCEL_ENV` is evaluated during static generation and the production build statically renders the 404 into `.next/server/app/_test.html`. There is no per-request cost and no way for the real page to leak through.

`test.mdx` and `test.d.mdx.ts` are untouched.

## Verification

- `npm run lint` and `npm run build` pass.
- Normal build + `npm start`: `/_test` returns 200 and renders normally, with `<meta name="robots" content="noindex, nofollow">` present.
- `VERCEL_ENV=production npm run build` + `npm start`: `/_test` returns **404** with `<title>404 | Ryan Rishi</title>`. The prerendered `_test.html` artifact is itself the 404 page, confirming the gate resolves at build time — the server was started *without* `VERCEL_ENV` set and still 404s.
- `npx cypress run --spec cypress/e2e/test_page.cy.js` against a normal build: all specs pass (6 passing, 0 failing, 10 pending from pre-existing `describe.skip` blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)