### PR TITLE
Add sitemap, robots.txt, and RSS feed

### DIFF
--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,43 @@
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/metadata'
+import { getAllPosts } from '@/lib/posts'
+
+export const dynamic = 'force-static'
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export async function GET() {
+  const posts = await getAllPosts()
+
+  const items = posts.map((post) => {
+    const link = `${SITE_URL}/blog/${post.slug}`
+    return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${link}</link>
+      <description>${escapeXml(post.description)}</description>
+      <pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>
+      <guid isPermaLink="true">${link}</guid>
+    </item>`
+  }).join('\n')
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>${escapeXml(SITE_NAME)}</title>
+    <link>${SITE_URL}</link>
+    <description>${escapeXml(SITE_DESCRIPTION)}</description>
+${items}
+  </channel>
+</rss>
+`
+
+  return new Response(feed, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     template: `%s | ${SITE_NAME}`,
   },
   description: SITE_DESCRIPTION,
+  alternates: {
+    types: { 'application/rss+xml': '/feed.xml' },
+  },
   authors: {
     name: SITE_NAME,
     url: new URL(SITE_URL),

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,7 +7,6 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: '/_test',
     },
     sitemap: `${SITE_URL}/sitemap.xml`,
   }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+import { SITE_URL } from '@/lib/metadata'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/_test',
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -22,11 +22,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...staticRoutes.map(route => ({ url: `${SITE_URL}${route}` })),
     ...posts.map(post => ({
       url: `${SITE_URL}/blog/${post.slug}`,
-      lastModified: post.publishedAt,
+      lastModified: new Date(post.publishedAt),
     })),
     ...projects.map(project => ({
       url: `${SITE_URL}/projects/${project.slug}`,
-      lastModified: project.date,
+      lastModified: new Date(project.date),
     })),
     ...tags.map(tag => ({ url: `${SITE_URL}/tags/${kebabCase(tag)}` })),
   ]

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from 'next'
+
+import { kebabCase } from '@/lib/kebab-case'
+import { SITE_URL } from '@/lib/metadata'
+import { getAllPosts } from '@/lib/posts'
+import { getAllProjects } from '@/lib/projects'
+
+const staticRoutes = ['', '/blog', '/projects', '/music', '/contact', '/links', '/tags']
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [posts, projects] = await Promise.all([
+    getAllPosts(),
+    getAllProjects(),
+  ])
+
+  const tags = Array.from(new Set([
+    ...posts.flatMap(post => post.tags),
+    ...projects.flatMap(project => project.tags ?? []),
+  ]))
+
+  return [
+    ...staticRoutes.map(route => ({ url: `${SITE_URL}${route}` })),
+    ...posts.map(post => ({
+      url: `${SITE_URL}/blog/${post.slug}`,
+      lastModified: post.publishedAt,
+    })),
+    ...projects.map(project => ({
+      url: `${SITE_URL}/projects/${project.slug}`,
+      lastModified: project.date,
+    })),
+    ...tags.map(tag => ({ url: `${SITE_URL}/tags/${kebabCase(tag)}` })),
+  ]
+}

--- a/cypress/e2e/feed.cy.js
+++ b/cypress/e2e/feed.cy.js
@@ -1,0 +1,34 @@
+describe('RSS feed', () => {
+  beforeEach(() => {
+    cy.request('/feed.xml').as('feed')
+  })
+
+  it('responds with RSS content type', function () {
+    expect(this.feed.status).to.eq(200)
+    expect(this.feed.headers['content-type']).to.eq('application/rss+xml; charset=utf-8')
+  })
+
+  it('is well-formed XML', function () {
+    const doc = new DOMParser().parseFromString(this.feed.body, 'application/xml')
+
+    expect(doc.querySelector('parsererror')).to.be.null
+    expect(doc.documentElement.nodeName).to.eq('rss')
+  })
+
+  it('has a channel with items', function () {
+    const doc = new DOMParser().parseFromString(this.feed.body, 'application/xml')
+
+    expect(doc.querySelector('channel > title').textContent).to.eq('Ryan Rishi')
+    expect(doc.querySelectorAll('channel > item').length).to.be.greaterThan(0)
+  })
+
+  it('each item has a title, an absolute link, and a valid pubDate', function () {
+    const doc = new DOMParser().parseFromString(this.feed.body, 'application/xml')
+
+    doc.querySelectorAll('channel > item').forEach((item) => {
+      expect(item.querySelector('title').textContent).to.not.be.empty
+      expect(item.querySelector('link').textContent).to.match(/^https:\/\/ryanrishi\.com\/blog\/.+/)
+      expect(new Date(item.querySelector('pubDate').textContent).toString()).to.not.eq('Invalid Date')
+    })
+  })
+})


### PR DESCRIPTION
The site had no sitemap, no robots.txt, and no RSS feed. This adds all three.

## New routes

- **`/sitemap.xml`** (`app/sitemap.ts`) — static routes (`/`, `/blog`, `/projects`, `/music`, `/contact`, `/links`, `/tags`), one entry per blog post and project with `lastModified`, and one per unique tag across both. 32 URLs total. No `changeFrequency`/`priority` tuning.
- **`/robots.txt`** (`app/robots.ts`) — allow all user agents on `/`, plus a sitemap reference.
- **`/feed.xml`** (`app/feed.xml/route.ts`) — RSS 2.0 over `getAllPosts()`, blog posts only. **Hand-built with a template string and a small XML-escape helper — no new dependency.** `export const dynamic = 'force-static'` so it is generated at build time like the rest of the site.

Feed discovery is declared via `alternates.types` in `app/layout.tsx`, which renders `<link rel="alternate" type="application/rss+xml" href="https://ryanrishi.com/feed.xml"/>`.

All three build as static routes.

## Notes for review

**Tag slug parity.** Sitemap tag URLs must match the routes `generateStaticParams` produces. Both now use `kebabCase` from `app/lib/kebab-case.ts` (landed in #534). Parity was verified against the old `lodash.kebabcase` for all 11 current tags, including the multi-word `a cappella` and `data visualization`:

`wordle`, `terraform`, `aws`, `data-visualization`, `cloudfront`, `jekylll`, `travis`, `music`, `a-cappella`, `homelab`, `python`

**Untagged projects.** Three projects have no `tags` frontmatter, so the sitemap uses `project.tags ?? []` to avoid a `flatMap` over `undefined` (this crashed the prerender before the guard was added). The existing `generateStaticParams` has the same latent issue but fails silently rather than throwing, since `kebabCase(undefined)` returned `''`. Not addressed here — possible follow-up.

**`lastModified` normalization.** Frontmatter dates are passed through `new Date(...)` rather than verbatim. Two values were irregular: the 2015 post has a `-0700` offset missing its colon (not valid W3C Datetime), and one project has a bare `2023-11-26`. All 14 `<lastmod>` values now serialize uniformly as ISO 8601 UTC.

**`/_test`.** Excluded from the sitemap. No robots.txt `Disallow` — after #532 the page is gated out of production builds and carries `noindex, nofollow` on previews, so listing it in a public file would only advertise a path that no longer resolves.

## Verification

- `npm run lint` clean; `npm run build` passes and lists `/sitemap.xml`, `/robots.txt`, `/feed.xml` as static (`○`).
- `curl /sitemap.xml` — 32 URLs: 7 static, 5 posts, 9 projects, 11 tags. Zero matches for `_test`. Passes `xmllint`.
- `curl /robots.txt` — allow rule and sitemap line present, no `_test` reference.
- `curl /feed.xml` — passes `xmllint --noout`, 5 items, absolute links, RFC 822 `pubDate`s, `content-type: application/rss+xml; charset=utf-8`.
- Spot-checks all 200: `/blog/2022-01-31-solving-wordle`, `/projects/loudness-wars`, `/tags/a-cappella`, `/tags/data-visualization`.
- `cypress/e2e/feed.cy.js` — 4 request-based tests covering status, content type, XML well-formedness, and per-item link/date shape. No Percy snapshot (XML, not a visual page). Assertions avoid hardcoded item counts and titles so new posts do not break them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)