### PR TITLE
Replace lodash devDependencies with local kebabCase

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -2,11 +2,11 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import fs from 'fs'
 import matter from 'gray-matter'
-import kebabCase from 'lodash.kebabcase'
 import type { Metadata } from 'next'
 import path from 'path'
 
 import TagPill from '@/components/tag-pill'
+import { kebabCase } from '@/lib/kebab-case'
 import { baseOpenGraph, baseTwitter, ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 

--- a/app/(site)/projects/[slug]/page.tsx
+++ b/app/(site)/projects/[slug]/page.tsx
@@ -1,10 +1,10 @@
 import fs from 'fs'
 import matter from 'gray-matter'
-import kebabCase from 'lodash.kebabcase'
 import { Metadata } from 'next'
 import path from 'path'
 
 import TagPill from '@/components/tag-pill'
+import { kebabCase } from '@/lib/kebab-case'
 import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllProjects } from '@/lib/projects'
 

--- a/app/(site)/tags/[tag]/page.tsx
+++ b/app/(site)/tags/[tag]/page.tsx
@@ -1,9 +1,8 @@
-import isEmpty from 'lodash.isempty'
-import kebabCase from 'lodash.kebabcase'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import Link from '@/components/link'
+import { kebabCase } from '@/lib/kebab-case'
 import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 import { getAllProjects } from '@/lib/projects'
@@ -15,8 +14,8 @@ export async function generateStaticParams() {
   ])
 
   const allTags = Array.from(new Set([
-    ...posts.flatMap(post => post.tags),
-    ...projects.flatMap(project => project.tags),
+    ...posts.flatMap(post => post.tags ?? []),
+    ...projects.flatMap(project => project.tags ?? []),
   ]))
 
   return allTags.map(tag => ({ tag: kebabCase(tag) }))
@@ -55,7 +54,7 @@ export default async function Tag({ params }: { params: Promise<{ tag: string }>
   const postsWithTag = posts.filter(post => post.tags.map(kebabCase).includes(tag))
   const projectsWithTag = projects.filter(project => project.tags?.map(kebabCase).includes(tag))
 
-  if (isEmpty(postsWithTag) && isEmpty(projectsWithTag)) {
+  if (postsWithTag.length === 0 && projectsWithTag.length === 0) {
     notFound()
   }
 
@@ -63,14 +62,14 @@ export default async function Tag({ params }: { params: Promise<{ tag: string }>
     <>
       <div className="prose dark:prose-invert">
         <h1>Content tagged with <code>{tag.replace('-', ' ')}</code></h1>
-        {!isEmpty(postsWithTag) && <h3>Posts</h3>}
+        {postsWithTag.length > 0 && <h3>Posts</h3>}
         {postsWithTag.map((post) => (
           <li key={post.slug}>
             <Link href={`/blog/${post.slug}`}>{post.title}</Link>
           </li>
         ))}
 
-        {!isEmpty(projectsWithTag) && <h3>Projects</h3>}
+        {projectsWithTag.length > 0 && <h3>Projects</h3>}
         {projectsWithTag.map((project) => (
           <li key={project.slug}>
             <Link href={`/projects/${project.slug}`}>{project.name}</Link>

--- a/app/(site)/tags/page.tsx
+++ b/app/(site)/tags/page.tsx
@@ -1,8 +1,8 @@
-import kebabCase from 'lodash.kebabcase'
 import type { Metadata } from 'next'
 
 import { FancyH1 } from '@/components/headings'
 import TagPill from '@/components/tag-pill'
+import { kebabCase } from '@/lib/kebab-case'
 import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
 import { getAllProjects } from '@/lib/projects'

--- a/app/lib/kebab-case.ts
+++ b/app/lib/kebab-case.ts
@@ -1,0 +1,3 @@
+export function kebabCase(str: string): string {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,6 @@
         "cypress-wait-until": "^3.0.2",
         "eslint": "9",
         "eslint-plugin-cypress": "^6.4.1",
-        "lodash.isempty": "^4.4.0",
-        "lodash.kebabcase": "^4.1.1",
         "postcss": "8.5.22",
         "start-server-and-test": "3.0.5",
         "tailwindcss": "^4.3.1",
@@ -8643,20 +8641,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
     "cypress-wait-until": "^3.0.2",
     "eslint": "9",
     "eslint-plugin-cypress": "^6.4.1",
-    "lodash.isempty": "^4.4.0",
-    "lodash.kebabcase": "^4.1.1",
     "postcss": "8.5.22",
     "start-server-and-test": "3.0.5",
     "tailwindcss": "^4.3.1",


### PR DESCRIPTION
## Problem

`lodash.kebabcase` and `lodash.isempty` were listed in `devDependencies` but imported by production page components:

- `app/(site)/blog/[slug]/page.tsx`
- `app/(site)/projects/[slug]/page.tsx`
- `app/(site)/tags/page.tsx`
- `app/(site)/tags/[tag]/page.tsx`

Any `npm ci --omit=dev` build would fail to resolve them.

## Changes

- Add `app/lib/kebab-case.ts` and point the four call sites at it.
- Replace `isEmpty(x)` with `x.length === 0` / `x.length > 0` in `app/(site)/tags/[tag]/page.tsx` (only ever called on arrays).
- Drop both packages from `devDependencies`. The lockfile diff touches nothing but those two entries.

## Slug parity

Tag URLs are public routes, so every tag in blog and project frontmatter was checked against `lodash.kebabcase` before the swap. All 11 tags produce identical slugs, including the multi-word ones (`a cappella` -> `a-cappella`, `data visualization` -> `data-visualization`). No URLs change.

## Incidental fix

Three projects (`homelab`, `treefort-2019`, `iheart-hackweek-2019`) have no `tags` frontmatter, so `flatMap` fed `undefined` into `generateStaticParams`. `lodash.kebabcase(undefined)` silently returned `''` and produced a bogus empty-string tag route; the local implementation throws instead, which surfaced this at build time. Fixed with `?? []` in the aggregation — the tags index page already guarded against the same falsy entries. `/tags/[tag]` now prerenders exactly 11 routes.

## Merge note

`app/lib/kebab-case.ts` is also created by the concurrent sitemap PR with identical contents, so the merge is a trivial add/add.

## Verification

- `npm run lint` — clean
- `npm run build` — succeeds, 11 tag routes prerendered
- `npx cypress run --spec cypress/e2e/tags.cy.js,cypress/e2e/blog.cy.js,cypress/e2e/projects.cy.js` — 13/13 passing
- `/tags`, `/tags/data-visualization`, `/tags/a-cappella` all return 200; an unknown tag still 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
