### PR TITLE
Fix tag page list markup and multi-hyphen tag heading

### DIFF
--- a/app/(site)/tags/[tag]/page.tsx
+++ b/app/(site)/tags/[tag]/page.tsx
@@ -61,20 +61,32 @@ export default async function Tag({ params }: { params: Promise<{ tag: string }>
   return (
     <>
       <div className="prose dark:prose-invert">
-        <h1>Content tagged with <code>{tag.replace('-', ' ')}</code></h1>
-        {postsWithTag.length > 0 && <h3>Posts</h3>}
-        {postsWithTag.map((post) => (
-          <li key={post.slug}>
-            <Link href={`/blog/${post.slug}`}>{post.title}</Link>
-          </li>
-        ))}
+        <h1>Content tagged with <code>{tag.replaceAll('-', ' ')}</code></h1>
+        {postsWithTag.length > 0 && (
+          <>
+            <h3>Posts</h3>
+            <ul>
+              {postsWithTag.map((post) => (
+                <li key={post.slug}>
+                  <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
 
-        {projectsWithTag.length > 0 && <h3>Projects</h3>}
-        {projectsWithTag.map((project) => (
-          <li key={project.slug}>
-            <Link href={`/projects/${project.slug}`}>{project.name}</Link>
-          </li>
-        ))}
+        {projectsWithTag.length > 0 && (
+          <>
+            <h3>Projects</h3>
+            <ul>
+              {projectsWithTag.map((project) => (
+                <li key={project.slug}>
+                  <Link href={`/projects/${project.slug}`}>{project.name}</Link>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
       </div>
 
       <div className="flex items-center justify-center my-8">


### PR DESCRIPTION
Two small fixes to `app/(site)/tags/[tag]/page.tsx`.

## Changes

- **Invalid list markup.** The posts and projects sections rendered bare `<li>` elements with no surrounding `<ul>`. Each group is now wrapped in a `<ul>`, with the heading and list together inside the existing emptiness check.
- **Only the first hyphen replaced in the heading.** `tag.replace('-', ' ')` → `tag.replaceAll('-', ' ')`, so a tag kebab-cased from three or more words (e.g. `machine-learning-ops`) renders every hyphen as a space instead of "machine learning-ops".

No test changes were needed — `cypress/e2e/tags.cy.js` never asserted on the bare-`<li>` structure.

## Verification

- `npm run lint` — clean, no output.
- `npm run build` — succeeds; all 12 `/tags/[tag]` routes prerender.
- `npm start`, `/tags/data-visualization` — heading reads "Content tagged with `data visualization`"; markup is now `<h3>Posts</h3><ul><li>…</li></ul><h3>Projects</h3><ul><li>…</li>…</ul>`. Linked pages (`/blog/2020-01-17-tufte`, `/projects/loudness-wars`, `/tags`) all return 200.
- `npx cypress run --spec cypress/e2e/tags.cy.js` — 3 passing, 0 failing.

## Not included

The plan's third item (misindented JSX in `app/layout.tsx`) no longer applies. The layout was split since the plan was written: the chrome now lives in `app/components/site-chrome.tsx` and is already correctly indented, so there was nothing to reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
