### PR TITLE
Drop dayjs, date-fns, and unified

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -1,16 +1,13 @@
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
 import fs from 'fs'
 import matter from 'gray-matter'
 import type { Metadata } from 'next'
 import path from 'path'
 
 import TagPill from '@/components/tag-pill'
+import { formatDate } from '@/lib/format-date'
 import { kebabCase } from '@/lib/kebab-case'
 import { baseOpenGraph, baseTwitter, ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
-
-dayjs.extend(utc)
 
 export const dynamicParams = false
 
@@ -62,7 +59,7 @@ export default async function Post({ params }: { params: Promise<{ slug: string 
   return (
     <>
       <h1>{frontmatter.title}</h1>
-      <p className="-mt-4 font-mono text-sm text-slate-500">{dayjs.utc(frontmatter.publishedAt).format('MMMM D, YYYY')}</p>
+      <p className="-mt-4 font-mono text-sm text-slate-500">{formatDate(frontmatter.publishedAt)}</p>
 
       <Post />
 

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -1,13 +1,10 @@
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
 import { Metadata } from 'next'
 
 import ContentRow from '@/components/content-row'
 import { FancyH1 } from '@/components/headings'
+import { formatDate } from '@/lib/format-date'
 import { baseOpenGraph, baseTwitter, ogImage, SITE_URL } from '@/lib/metadata'
 import { getAllPosts } from '@/lib/posts'
-
-dayjs.extend(utc)
 
 const title = 'Blog'
 const description = 'Writing about technology, music, and life.'
@@ -42,7 +39,7 @@ export default async function BlogIndex() {
             key={post.slug}
             href={`/blog/${post.slug}`}
             title={post.title}
-            date={dayjs.utc(post.publishedAt).format('MMMM D, YYYY')}
+            date={formatDate(post.publishedAt)}
             description={post.description}
             headingLevel="h2"
             rowProps={{ 'data-test-blog-post': true }}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,16 +1,12 @@
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import { compareDesc } from 'date-fns'
 import NextLink from 'next/link'
 import { ReactNode } from 'react'
 
 import ContentRow from '@/components/content-row'
 import { FancyH1 } from '@/components/headings'
 import Link from '@/components/link'
+import { formatShortDate } from '@/lib/format-date'
 import { getAllPosts } from '@/lib/posts'
 import { getAllProjects } from '@/lib/projects'
-
-dayjs.extend(utc)
 
 interface SectionProps {
   title: { text: string; url?: string; }
@@ -47,8 +43,8 @@ export default async function Index() {
     getAllProjects(),
   ])
 
-  const recentPosts = posts.sort((a, b) => compareDesc(new Date(a.publishedAt), new Date(b.publishedAt))).slice(0, 3)
-  const recentProjects = projects.sort((a, b) => compareDesc(new Date(a.date), new Date(b.date))).slice(0, 3)
+  const recentPosts = posts.slice(0, 3)
+  const recentProjects = projects.slice(0, 3)
 
   return (
     <>
@@ -74,7 +70,7 @@ export default async function Index() {
             key={post.slug}
             href={`/blog/${post.slug}`}
             title={post.title}
-            date={dayjs.utc(post.publishedAt).format('MMM YYYY')}
+            date={formatShortDate(post.publishedAt)}
             description={post.description}
           />
         ))}
@@ -90,7 +86,7 @@ export default async function Index() {
             key={project.slug}
             href={`/projects/${project.slug}`}
             title={project.name}
-            date={dayjs.utc(project.date).format('MMM YYYY')}
+            date={formatShortDate(project.date)}
             description={project.description}
           />
         ))}

--- a/app/(site)/projects/page.tsx
+++ b/app/(site)/projects/page.tsx
@@ -1,4 +1,3 @@
-import { compareDesc } from 'date-fns'
 import { Metadata } from 'next'
 
 import { FancyH1 } from '@/components/headings'
@@ -35,16 +34,13 @@ export default async function ProjectsIndex() {
     <>
       <FancyH1>Projects</FancyH1>
       <ul className="grid grid-cols-1 md:grid-cols-3 gap-8">
-        {projects
-          .sort((a, b) => compareDesc(new Date(a.date), new Date(b.date)))
-          .map((project, i) =>
-            <ProjectItem
-              project={project}
-              index={i}
-              key={i}
-            />
-          )
-        }
+        {projects.map((project, i) =>
+          <ProjectItem
+            project={project}
+            index={i}
+            key={i}
+          />
+        )}
       </ul>
     </>
   )

--- a/app/lib/format-date.ts
+++ b/app/lib/format-date.ts
@@ -1,0 +1,20 @@
+const longFormat = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+const shortFormat = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+export function formatDate(date: string): string {
+  return longFormat.format(new Date(date))
+}
+
+export function formatShortDate(date: string): string {
+  return shortFormat.format(new Date(date))
+}

--- a/app/lib/posts.ts
+++ b/app/lib/posts.ts
@@ -1,4 +1,3 @@
-import { compareDesc } from 'date-fns'
 import fs from 'fs/promises'
 import matter from 'gray-matter'
 import path from 'path'
@@ -25,5 +24,5 @@ export async function getAllPosts(): Promise<Post[]> {
       return { slug, ...data } as Post
     })
   )
-  return posts.sort((a, b) => compareDesc(new Date(a.publishedAt), new Date(b.publishedAt)))
+  return posts.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime())
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
         "@vercel/speed-insights": "^2.0.0",
         "classnames": "^2.3.1",
         "d3": "^7.9.0",
-        "date-fns": "^4.4.0",
-        "dayjs": "^1.11.21",
         "eslint-config-next": "^16.2.9",
         "framer-motion": "12.38.0",
         "geist": "^1.7.2",
@@ -36,8 +34,7 @@
         "remark-gfm": "4.0.1",
         "remark-mdx-frontmatter": "^5.2.0",
         "sharp": "^0.35.1",
-        "shiki": "^4.3.1",
-        "unified": "^11.0.5"
+        "shiki": "^4.3.1"
       },
       "devDependencies": {
         "@percy/cli": "^1.31.13",
@@ -5196,20 +5193,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
       "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "@vercel/speed-insights": "^2.0.0",
     "classnames": "^2.3.1",
     "d3": "^7.9.0",
-    "date-fns": "^4.4.0",
-    "dayjs": "^1.11.21",
     "eslint-config-next": "^16.2.9",
     "framer-motion": "12.38.0",
     "geist": "^1.7.2",
@@ -40,8 +38,7 @@
     "remark-gfm": "4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "sharp": "^0.35.1",
-    "shiki": "^4.3.1",
-    "unified": "^11.0.5"
+    "shiki": "^4.3.1"
   },
   "devDependencies": {
     "@percy/cli": "^1.31.13",


### PR DESCRIPTION
## What changed

Removes three dependencies:

- **`dayjs`** — only used for display formatting. Replaced with `Intl.DateTimeFormat` in a new `app/lib/format-date.ts` exporting `formatDate` (`January 31, 2022`) and `formatShortDate` (`Jan 2022`). Both pin `timeZone: 'UTC'`, matching the `dayjs.utc()` the old code used to avoid off-by-one-day rendering.
- **`date-fns`** — only used for `compareDesc`. `app/lib/posts.ts` now sorts with plain `Date` subtraction, matching what `app/lib/projects.ts` already did.
- **`unified`** — not imported anywhere.

Also drops the redundant `.sort(...)` calls on `app/(site)/page.tsx` and `app/(site)/projects/page.tsx` — `getAllPosts()` and `getAllProjects()` already return sorted results.

## Verification

- `npm run lint` — clean, no output.
- `npm run build` — passes, all 41 static pages generated.
- **Format parity:** compared `dayjs.utc(d).format('MMMM D, YYYY')` / `'MMM YYYY'` against the new `Intl` formatters across all 14 real frontmatter dates in `app/(site)/blog` and `app/(site)/projects` — **0 mismatches**. `"2022-01-31T00:00:00Z"` renders `January 31, 2022` / `Jan 2022` as before.
- **Rendered output** from a production server:
  - `/blog` — `January 31, 2022`, `June 1, 2020`, `January 17, 2020`, `January 6, 2020`, `December 27, 2015` (newest-first)
  - `/` — posts `Jan 2022`, `Jun 2020`, `Jan 2020`; projects `Nov 2023`, `Jan 2023`, `Jul 2021` (both newest-first)
  - `/blog/2022-01-31-solving-wordle` — `January 31, 2022`
  - `/projects` — order matches frontmatter dates descending (2023-11-26 → 2018-05-18)
- **Headless Cypress** (`blog.cy.js`, `home.cy.js`, `projects.cy.js`) — 16/16 passing, 0 failing.

`dayjs` remains in the lockfile as a transitive **dev** dependency (Percy); `unified` remains as a transitive dependency of the remark/rehype toolchain. Neither is a direct dependency anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)