### PR TITLE
chore: remove dead covid-19-dashboard redirect and refresh stale docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 This repository contains the source for my personal website built with **Next.js** and **TypeScript**. The following folders are important:
 
-- `app/` – Next.js "app" directory. Pages live directly under this folder and reusable pieces go in `app/components`.
+- `app/` – Next.js "app" directory. Chromed pages live in the `app/(site)/` route group and reusable pieces go in `app/components`.
+- `app/(site)/blog/` and `app/(site)/projects/` – MDX content with YAML frontmatter, parsed at build time by `app/lib/posts.ts` and `app/lib/projects.ts`.
 - `branding/` – logo and branding assets.
-- `content/` – Markdown/MDX files processed by Contentlayer (blog posts in `content/blog`, projects in `content/projects`, etc.).
 - `public/` – static assets served as-is.
 - `cypress/` – end to end tests written with Cypress.
 - `terraform/` – Terraform files for infrastructure.
@@ -13,8 +13,8 @@ This repository contains the source for my personal website built with **Next.js
 
 - Use **npm** for all scripts and dependency changes.
 - Code is formatted with two spaces and no semicolons. Follow `.editorconfig` and `eslint` rules.
-- Keep imports sorted via `eslint-plugin-simple-import-sort`.
-- New pages should be placed in `app` and components in `app/components`.
+- Keep imports sorted.
+- New pages should be placed in `app/(site)` and components in `app/components`.
 
 ## Checks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run lint` - Run ESLint
 
 ### Testing
-- `npm test` - Run Cypress tests (opens interactive test runner)
+- `npm test` - Start the production server and open the interactive Cypress runner (run `npm run build` first)
 - Tests are located in `cypress/e2e/`
 
 #### Percy Visual Testing
-- Requires `PERCY_PAGE_LOAD_TIMEOUT=60000` environment variable for CI
-- This prevents timeout issues on the projects page with multiple images
-- Cypress has custom `waitForImagesLoaded` command with 60s timeout
+- CI runs Cypress under `percy exec --` (`.github/workflows/cypress.yml`)
+- Cypress has custom `waitForImagesLoaded` command with 60s timeout to avoid timeouts on the projects page with multiple images
 
 ### Contact Form Development
 When working on the contact form, add an entry to `/etc/hosts` using a subdomain of allowed Formspree domains:
@@ -28,44 +27,45 @@ local.ryanrishi.com  127.0.0.1
 
 ## Architecture Overview
 
-This is a Next.js 14 personal website with the following key characteristics:
+This is a Next.js personal website with the following key characteristics:
 
 ### Content Management
 - **Blog Posts**: MDX files in `app/(site)/blog/` with frontmatter metadata
 - **Projects**: MDX files in `app/(site)/projects/` with frontmatter metadata  
-- **Content Loading**: Server-side dynamic imports read metadata from MDX files at build time
+- **Content Loading**: `app/lib/posts.ts` and `app/lib/projects.ts` read MDX frontmatter from disk with `gray-matter` at build time
 - **Sorting**: Posts sorted by `publishedAt` date (desc), Projects sorted by `date` (desc)
 
 ### MDX Configuration
 - Uses `@next/mdx` with custom rehype/remark plugins
 - **Rehype plugins**: slug generation, autolink headings, pretty code highlighting
-- **Remark plugins**: frontmatter processing (note: remark-gfm currently disabled due to compatibility issues)
+- **Remark plugins**: GitHub Flavored Markdown, frontmatter processing
 - **Custom components**: Defined in `mdx-components.tsx` including Blockquote, Callout, Link, dynamic imports for Logo, LoudnessWars, VideoContainer
 - **Frontmatter handling**: Uses `gray-matter` to parse YAML frontmatter from MDX files at build time
 
 ### Styling & UI
-- **CSS Framework**: Tailwind CSS with custom `valencia` color palette
+- **CSS Framework**: Tailwind CSS v4, configured in `app/globals.css` via `@theme` (includes the custom `valencia` color palette)
 - **Dark Mode**: Class-based dark mode via `next-themes`
 - **Typography**: Uses `@tailwindcss/typography` plugin
-- **Safelist**: Dynamically generated for callout component colors (green, blue, yellow, red, slate)
+- **Safelist**: `@source inline(...)` rules in `app/globals.css` for the dynamic callout component colors (green, blue, yellow, red, slate)
 
 ### Page Structure
-- **App Router**: Next.js 13+ file-based routing in `app/` directory
+- **App Router**: file-based routing in the `app/` directory
 - **Route group**: Chromed pages live in an `app/(site)/` route group whose layout renders the shared `SiteChrome` (Header + container + Footer). The root layout holds only Providers + analytics, so `app/links/` renders chrome-free. `(site)` does not affect URLs.
 - **Layout**: Root layout wraps everything in Providers + Google/Vercel Analytics; `app/(site)/layout.tsx` adds the visible chrome. The 404 (`app/not-found.tsx`) renders inside `SiteChrome` to keep the chrome.
 - **Dynamic Routes**: `[slug]` patterns for blog posts and projects
 - **Tags**: Tag-based filtering for both blog and projects
+- **Route handlers**: `app/sitemap.ts`, `app/robots.ts`, `app/feed.xml/route.ts` (RSS), and `app/og/route.tsx` (OG images)
 
 ### Key Libraries
 - **Animations**: Framer Motion
 - **Dates**: date-fns for post sorting
 - **Icons**: react-icons
 - **Data Visualization**: D3.js (transpiled in next.config.mjs)
-- **Analytics**: Google Analytics + Vercel Analytics
+- **Analytics**: Google Analytics + Vercel Analytics/Speed Insights
 
 ### Data Flow
 1. MDX files contain frontmatter with metadata (title, description, publishedAt/date, tags)
-2. `lib/posts.ts` and `lib/projects.ts` dynamically import and aggregate metadata
+2. `app/lib/posts.ts` and `app/lib/projects.ts` parse and aggregate that frontmatter
 3. Pages use these functions to render lists and individual content
 4. All content is statically generated at build time
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ This is a Next.js personal website with the following key characteristics:
 
 ### Key Libraries
 - **Animations**: Framer Motion
-- **Dates**: date-fns for post sorting
+- **Dates**: no date library — `app/lib/format-date.ts` wraps `Intl.DateTimeFormat`, and sorting compares `Date.getTime()`
 - **Icons**: react-icons
 - **Data Visualization**: D3.js (transpiled in next.config.mjs)
 - **Analytics**: Google Analytics + Vercel Analytics/Speed Insights

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,11 +10,6 @@ const nextConfig = {
         destination: '/blog/:year-:month-:day-:post',
         permanent: false,
       },
-      {
-        source: '/covid-19-dashboard',
-        destination: 'https://labs.ryanrishi.com/covid-19-dashboard/',
-        permanent: false,
-      },
     ]
   },
   transpilePackages: [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,11 @@ const nextConfig = {
         destination: '/blog/:year-:month-:day-:post',
         permanent: false,
       },
+      {
+        source: '/covid-19-dashboard',
+        destination: 'https://labs.ryanrishi.com/covid-19-dashboard/',
+        permanent: false,
+      },
     ]
   },
   transpilePackages: [

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "redirects": [
-    {
-      "source": "/covid-19-dashboard",
-      "destination": "https://labs.ryanrishi.com/covid-19-dashboard/"
-    }
-  ]
-}


### PR DESCRIPTION
## Redirect config

`vercel.json` is deleted. Its only content was a `/covid-19-dashboard` → `https://labs.ryanrishi.com/covid-19-dashboard/` redirect, and that redirect is **removed rather than migrated**: `labs.ryanrishi.com` still resolves but returns 502, so the redirect was sending visitors to a broken endpoint.

`/covid-19-dashboard` now 404s. `next.config.mjs` is unchanged from `main` — the legacy blog-URL redirect stays exactly as it was, and `/projects/covid-19-dashboard` (a real MDX project page) is unaffected.

## Docs

Corrected stale claims in `CLAUDE.md`:

- "a Next.js 14 personal website" → version dropped entirely (package.json has `next ^16.2.11`)
- "(note: remark-gfm currently disabled due to compatibility issues)" — it *is* enabled in `next.config.mjs`
- "App Router: Next.js 13+ file-based routing" → version dropped
- `PERCY_PAGE_LOAD_TIMEOUT=60000` "required for CI" — that variable is set nowhere in the repo; replaced with how Percy actually runs in CI (`percy exec --` in `.github/workflows/cypress.yml`)
- `npm test` — clarified it starts the *production* server via `start-server-and-test`, so `npm run build` must run first
- "Content Loading: Server-side dynamic imports read metadata" — `app/lib/posts.ts` / `app/lib/projects.ts` read from disk with `gray-matter`
- Data Flow referenced `lib/posts.ts` / `lib/projects.ts`; the real paths are `app/lib/...`
- Tailwind is v4 with no config file; theme and `valencia` palette live in `app/globals.css` under `@theme`, and the callout "safelist" is `@source inline(...)` there
- Added the route handlers that already exist but were undocumented: `app/sitemap.ts`, `app/robots.ts`, `app/feed.xml/route.ts`, `app/og/route.tsx`
- Analytics also includes Vercel Speed Insights
- "Dates: date-fns for post sorting" — after #536 there is no date library at all; sorting compares `Date.getTime()` and formatting goes through `app/lib/format-date.ts` (`Intl.DateTimeFormat`)

And in `AGENTS.md`:

- Removed the `content/` directory entry — that folder does not exist and Contentlayer is not used; content is MDX under `app/(site)/blog` and `app/(site)/projects`
- `app/` description and "new pages go in `app`" updated for the `app/(site)/` route group
- Dropped the `eslint-plugin-simple-import-sort` reference — it is not installed or configured (`eslint.config.mjs` is `eslint-config-next` + `eslint-plugin-cypress`)

## Verification

- `npm run lint` — clean, no output
- `npm run build` — succeeds, 41 static pages
- `/covid-19-dashboard` → `404`
- `/projects/covid-19-dashboard` → `200`
- `/2020/01/06/migrating-my-website-to-aws-using-terraform.html` → `307`, `location: /blog/2020-01-06-migrating-my-website-to-aws-using-terraform` (pre-existing redirect unchanged)
- `npx cypress run` — full suite green: 15 specs, 64 passing, 0 failing (10 skipped are the production-gated `/_test` cases). `redirects.cy.js` only covers legacy blog URLs and never referenced `/covid-19-dashboard`, so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

